### PR TITLE
chore: use mrm to scaffold project files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+  build_10.15.3:
+    docker:
+      - image: 'circleci/node:10.15.3'
+    working_directory: ~/app
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - 'v1-dependencies-{{ checksum "package.json" }}'
+            - v1-dependencies-
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: 'v1-dependencies-{{ checksum "package.json" }}'
+      - run: npm test
+  build_latest:
+    docker:
+      - image: 'circleci/node:latest'
+    working_directory: ~/app
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - 'v1-dependencies-{{ checksum "package.json" }}'
+            - v1-dependencies-
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: 'v1-dependencies-{{ checksum "package.json" }}'
+      - run: npm test
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - build_10.15.3
+      - build_latest

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# http://editorconfig.org
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+insert_final_newline = ignore
+
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore
+
+[MakeFile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -1,0 +1,70 @@
+## Git Commit Message Convention
+
+> This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
+
+Using conventional commit messages, we can automate the process of generating the CHANGELOG file. All commits messages will automatically be validated against the following regex.
+
+``` js
+/^(revert: )?(feat|fix|docs|style|refactor|perf|test|workflow|ci|chore|types|build)((.+))?: .{1,50}/
+```
+
+## Commit Message Format
+A commit message consists of a **header**, **body** and **footer**. The header has a **type**, **scope** and **subject**:
+
+> The **scope** is optional
+
+```
+feat(router): add support for prefix
+
+Prefix makes it easier to append a path to a group of routes
+```
+
+1. `feat` is type.
+2. `router` is scope and is optional
+3. `add support for prefix` is the subject
+4. The **body** is followed by a blank line.
+5. The optional **footer** can be added after the body, followed by a blank line.
+
+## Types
+Only one type can be used at a time and only following types are allowed.
+
+- feat
+- fix
+- docs
+- style
+- refactor
+- perf
+- test
+- workflow
+- ci
+- chore
+- types
+- build
+
+If a type is `feat`, `fix` or `perf`, then the commit will appear in the CHANGELOG.md file. However if there is any BREAKING CHANGE, the commit will always appear in the changelog.
+
+### Revert
+If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>`., where the hash is the SHA of the commit being reverted.
+
+## Scope
+The scope could be anything specifying place of the commit change. For example: `router`, `view`, `querybuilder`, `database`, `model` and so on.
+
+## Subject
+The subject contains succinct description of the change:
+
+- use the imperative, present tense: "change" not "changed" nor "changes".
+- don't capitalize first letter
+- no dot (.) at the end
+
+## Body
+
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+## Footer
+
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->
+
+## Prerequisites
+
+We do our best to reply to all the issues on time. If you will follow the given guidelines, the turn around time will be faster.
+
+- Ensure the issue isn't already reported.
+- Ensure you are reporting the bug in the correct repo.
+
+*Delete the above section and the instructions in the sections below before submitting*
+
+## Description
+
+If this is a feature request, explain why it should be added. Specific use-cases are best.
+
+For bug reports, please provide as much *relevant* info as possible.
+
+## Package version
+<!-- YOUR ANSWER -->
+
+## Error Message & Stack Trace
+
+## Relevant Information

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->
+
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+
+## Types of changes
+
+What types of changes does your code introduce?
+
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/thetutlage/hash/blob/master/CONTRIBUTING.md) doc
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] I have added necessary documentation (if appropriate)
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,15 @@
 /build
 package-lock.json
 yarn.lock
+node_modules
+coverage
+.DS_STORE
+.nyc_output
+.idea
+.vscode/
+*.sublime-project
+*.sublime-workspace
+*.log
+build
+dist
+shrinkwrap.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+message="chore(release): %s"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+We love pull requests. And following this guidelines will make your pull request easier to merge
+
+## Prerequisites
+
+- Install [EditorConfig](http://editorconfig.org/) plugin for your code editor to make sure it uses correct settings.
+- Fork the repository and clone your fork.
+- Install dependencies: `npm install`.
+
+## Coding style
+
+We make use of Typescript along with [Tslint](https://palantir.github.io/tslint) to ensure a consistent coding style. All of the rules are defined inside the `tslint.json` file.
+
+## Development work-flow
+
+Always make sure to lint and test your code before pushing it to the GitHub.
+
+```bash
+npm test
+```
+
+Just lint the code
+
+```bash
+npm run lint
+```
+
+**Make sure you add sufficient tests for the change**.
+
+## Other notes
+
+- Do not change version number inside the `package.json` file.
+- Do not update `CHANGELOG.md` file.
+- Do not update `tslint.json` or `tslint.js` file. If something prevents you writing code, please create an issue for same.
+
+## Need help?
+
+Feel free to ask.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+# The MIT License
+
+Copyright 2019 Romain Lanz, contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "core": false,
+  "ts": true,
+  "license": "MIT",
+  "services": [
+    "circleci"
+  ],
+  "minNodeVersion": "10.15.3"
+}

--- a/package.json
+++ b/package.json
@@ -2,18 +2,26 @@
   "name": "@slynova/hash",
   "version": "0.1.0",
   "description": "Flexible and Fluent framework-agnostic driver based system for password hashing algorithms.",
-  "main": "./build/index.js",
+  "main": "build/index.js",
+  "files": [
+    "build/src",
+    "build/index.d.ts",
+    "build/index.js"
+  ],
   "author": "Romain Lanz <romain.lanz@slynova.ch>",
   "license": "MIT",
-  "files": [
-    "build"
-  ],
   "scripts": {
-    "build": "npm run clean && npm run tsc",
-    "clean": "rimraf build",
-    "prepublishOnly": "npm run build",
-    "test": "node japaFile",
-    "tsc": "tsc"
+    "build": "npm run compile",
+    "clean": "del build",
+    "pretest": "npm run lint",
+    "test": "node japaFile.js",
+    "tsc": "tsc",
+    "mrm": "mrm --preset=@adonisjs/mrm-preset",
+    "lint": "tslint --project tsconfig.json",
+    "compile": "npm run lint && npm run clean && tsc",
+    "commit": "git-cz",
+    "release": "np",
+    "version": "npm run build"
   },
   "dependencies": {
     "argon2": "^0.24.0",
@@ -21,16 +29,24 @@
     "node-exceptions": "^4.0.1"
   },
   "devDependencies": {
+    "@adonisjs/mrm-preset": "^2.0.3",
     "@types/argon2": "^0.15.0",
     "@types/bcrypt": "^3.0.0",
     "@types/node": "^12.0.10",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "commitizen": "^3.1.1",
+    "cz-conventional-changelog": "^2.1.0",
+    "del-cli": "^2.0.0",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^6.0.0",
+    "husky": "^2.4.1",
     "japa": "^2.0.10",
+    "mrm": "^1.2.2",
+    "np": "^5.0.3",
     "prettier": "^1.18.2",
-    "rimraf": "^2.6.3",
     "ts-node": "^8.3.0",
+    "tslint": "^5.18.0",
+    "tslint-eslint-rules": "^5.4.0",
     "typescript": "^3.5.2"
   },
   "repository": "git@github.com:Slynova-Org/hash.git",
@@ -53,5 +69,27 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "printWidth": 120
+  },
+  "nyc": {
+    "exclude": [
+      "test"
+    ],
+    "extension": [
+      ".ts"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "node ./node_modules/@adonisjs/mrm-preset/validateCommit/conventional/validate.js"
+    }
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
+  },
+  "np": {
+    "contents": ".",
+    "anyBranch": false
   }
 }

--- a/src/Drivers/Argon2.ts
+++ b/src/Drivers/Argon2.ts
@@ -5,20 +5,20 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import argon2, { Options } from 'argon2'
+import * as argon2 from 'argon2'
 import Hash from '../Hash'
 
 export class Argon2 implements Hash {
   private $config: Argon2Config
 
-  constructor(config: Argon2Config) {
+  constructor (config: Argon2Config) {
     this.$config = config
   }
 
   /**
    * Hash a plain value using argon2.
    */
-  make(value: string, config?: Argon2Config): Promise<string> {
+  public make (value: string, config?: Argon2Config): Promise<string> {
     // @ts-ignore
     return argon2.hash(value, { ...this.$config, ...config })
   }
@@ -26,7 +26,7 @@ export class Argon2 implements Hash {
   /**
    * Verify an existing hash with the plain value.
    */
-  verify(value: string, hash: string): Promise<boolean> {
+  public verify (value: string, hash: string): Promise<boolean> {
     if (value === undefined) {
       return new Promise(resolve => resolve(false))
     }
@@ -35,4 +35,4 @@ export class Argon2 implements Hash {
   }
 }
 
-export interface Argon2Config extends Options {}
+export interface Argon2Config extends argon2.Options {}

--- a/src/Drivers/Bcrypt.ts
+++ b/src/Drivers/Bcrypt.ts
@@ -5,25 +5,28 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import bcrypt from 'bcrypt'
+import * as bcrypt from 'bcrypt'
 import Hash from '../Hash'
 
 export class Bcrypt implements Hash {
   private $config: BcryptConfig
 
-  constructor(config: BcryptConfig) {
+  constructor (config: BcryptConfig) {
     this.$config = config
   }
 
   /**
    * Hash a plain value using argon2.
    */
-  make(value: string, config?: BcryptConfig): Promise<string> {
+  public make (value: string, config?: BcryptConfig): Promise<string> {
     const rounds = config ? config.rounds : this.$config.rounds || 10
 
     return new Promise((resolve, reject) => {
       bcrypt.hash(value, rounds, (error, hash) => {
-        if (error) reject(error)
+        if (error) {
+          reject(error)
+          return
+        }
 
         resolve(hash)
       })
@@ -33,10 +36,13 @@ export class Bcrypt implements Hash {
   /**
    * Verify an existing hash with the plain value.
    */
-  verify(value: string, hash: string): Promise<boolean> {
+  public verify (value: string, hash: string): Promise<boolean> {
     return new Promise(resolve => {
       bcrypt.compare(value, hash, (error, same) => {
-        if (error) resolve(false)
+        if (error) {
+          resolve(false)
+          return
+        }
 
         resolve(same)
       })

--- a/src/Exceptions/DriverNotSupported.ts
+++ b/src/Exceptions/DriverNotSupported.ts
@@ -10,7 +10,7 @@ import { RuntimeException } from 'node-exceptions'
 export class DriverNotSupported extends RuntimeException {
   public driver: string
 
-  public static driver(name: string) {
+  public static driver (name: string) {
     const exception = new this(`Driver ${name} is not supported`, 400)
 
     exception.driver = name

--- a/src/Exceptions/InvalidConfig.ts
+++ b/src/Exceptions/InvalidConfig.ts
@@ -8,11 +8,11 @@
 import { RuntimeException } from 'node-exceptions'
 
 export class InvalidConfig extends RuntimeException {
-  public static missingDriverName() {
+  public static missingDriverName () {
     return new this('Make sure to define a default hash driver name inside config file', 500, 'E_INVALID_CONFIG')
   }
 
-  public static missingDriverConfig(name: string) {
+  public static missingDriverConfig (name: string) {
     return new this(`Make sure to define config for ${name} hash driver`, 500, 'E_INVALID_CONFIG')
   }
 }

--- a/src/Hash.ts
+++ b/src/Hash.ts
@@ -12,10 +12,10 @@ export default interface Hash {
   /**
    * Hash a plain value using argon2.
    */
-  make(value: string, config?: Argon2Config | BcryptConfig): Promise<string>
+  make (value: string, config?: Argon2Config | BcryptConfig): Promise<string>
 
   /**
    * Verify an existing hash with the plain value.
    */
-  verify(value: string, hash: string): Promise<boolean>
+  verify (value: string, hash: string): Promise<boolean>
 }

--- a/src/HashManager.ts
+++ b/src/HashManager.ts
@@ -17,11 +17,11 @@ export default class HashManager {
    */
   private _config: any
 
-  constructor(config) {
+  constructor (config) {
     this._config = config
   }
 
-  use<T extends Hash>(name?: string, config?: Argon2Config | BcryptConfig): T {
+  public use<T extends Hash> (name?: string, config?: Argon2Config | BcryptConfig): T {
     name = name || this._config.default
 
     /**

--- a/test/unit/argon2-driver.spec.ts
+++ b/test/unit/argon2-driver.spec.ts
@@ -5,7 +5,7 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import test from 'japa'
+import * as test from 'japa'
 import { Argon2 } from '../../src/Drivers/Argon2'
 
 test.group('Argon2 Driver', () => {

--- a/test/unit/bcrypt-driver.spec.ts
+++ b/test/unit/bcrypt-driver.spec.ts
@@ -5,7 +5,7 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import test from 'japa'
+import * as test from 'japa'
 import { Bcrypt } from '../../src/Drivers/Bcrypt'
 
 test.group('Bcrypt Driver', () => {

--- a/test/unit/hash-manager.spec.ts
+++ b/test/unit/hash-manager.spec.ts
@@ -5,7 +5,7 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import test from 'japa'
+import * as test from 'japa'
 import HashManager from '../../src/HashManager'
 import { Argon2 } from '../../src/Drivers/Argon2'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,3 @@
 {
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"],
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "lib": ["es2017"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noUnusedLocals": true,
-    "noUnusedParameters": false,
-    "outDir": "build",
-    "removeComments": false,
-    "strictNullChecks": true,
-    "target": "es2017"
-  }
+  "extends": "./node_modules/@adonisjs/mrm-preset/_tsconfig"
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "@adonisjs/mrm-preset/_tslint"
+  ],
+  "rules": {}
+}


### PR DESCRIPTION
Using MRM scaffold will result in following 

1. Adds `LICENSE.md` and `CONTRIBUTING.md` files.
2. Adds `.github` templates for PR and new issues.
3. `tsconfig` extends the default mrm config. Which means, it is easily upgradable. 
4. Add support for `circle` to run tests.
5. Enforce strict commit messages using `commit-msg` hook.
6. Use `np` for releases
7. Use `tslint` for consistent syntax.
8. Add `.editoconfig` for consistent spacing and new lines.